### PR TITLE
Added new custom MessageKind to support custom Messages.

### DIFF
--- a/CustomMessage.md
+++ b/CustomMessage.md
@@ -1,0 +1,31 @@
+# swifty_chat
+
+### Custom Message
+
+To create a custom message and look (`MessageKind.custom`) follow these steps below;
+
+1) Register a new custom message cell.
+
+```swift
+ChatView<MockMessages.ChatMessageItem, MockMessages.ChatUserItem>(messages: $messages) {
+    // [...]
+}
+    // ▼ Optional, Implement to register a custom cell for Messagekind.custom. CustomExampleChatCell is an example View.
+    .registerCustomCell(customCell: {anyParam in AnyView(CustomExampleChatCell(anyParam: anyParam))})
+```
+
+Since `customCell` has the type `(Any) -> AnyView` you can register any View and pass Any type.
+
+Be aware that you need to cast `anyParam` in `CustomExampleChatCell` to the expaced type
+
+2) Add a message to your dataSource with the `MessageKind.custom(dynamic custom)` option.
+
+Since `.custom` constructor expects a `dynamic` parameter you can pass any type.
+
+```swift
+MockMessages.ChatMessageItem(
+    user: MockMessages.chatbot,
+    messageKind: .custom("⚙️ Hey! This is my custom message!!!! ⚙️),
+    isSender: false
+)
+```

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Fully written in pure SwiftUI.
 - [x] Multiline Input Bar added (investigate [BasicInputView](../master/Sources/SwiftyChat/InputView/BasicInputView.swift))
 - [x] Scroll to bottom.
 - [x] Round specific corner of text messages.
+- [x] Implement custom message cells. See [CustomMessage.md](CustomMessage.md) for details.
 - [ ] Swipe to dismiss keyboard.
 
 
@@ -190,6 +191,8 @@ You must initiate this class to build a proper style & inject it as `environment
 All styles has default initializer; <br>
 
 For detail documentation, visit [Styles.md](../master/Styles.md)
+
+You can also use your own custom message cell, see [CustomMessage.md](CustomMessage.md) for details.
 
 <br>
 Please feel free to contribute.<br>

--- a/Sources/SwiftyChat/ChatMessageCellContainer.swift
+++ b/Sources/SwiftyChat/ChatMessageCellContainer.swift
@@ -13,6 +13,7 @@ internal struct ChatMessageCellContainer<Message: ChatMessage>: View {
     public let message: Message
     public let size: CGSize
     
+    public let customCell: ((Any) -> AnyView)?
     public let onQuickReplyItemSelected: (QuickReplyItem) -> Void
     public let contactFooterSection: (ContactItem, Message) -> [ContactCellButton]
     public let onTextTappedCallback: () -> AttributedTextTappedCallback
@@ -82,6 +83,11 @@ internal struct ChatMessageCellContainer<Message: ChatMessage>: View {
             
         case .loading:
             LoadingCell(message: message, size: size)
+            
+        case .custom(let custom):
+            if let cell = customCell {
+                cell(custom)
+            }
         }
         
     }

--- a/Sources/SwiftyChat/ChatView.swift
+++ b/Sources/SwiftyChat/ChatView.swift
@@ -13,6 +13,7 @@ public struct ChatView<Message: ChatMessage, User: ChatUser>: View {
     
     @Binding private var messages: [Message]
     private var inputView: () -> AnyView
+    private var customCellView: ((Any) -> AnyView)?
 
     private var onMessageCellTapped: (Message) -> Void = { msg in print(msg.messageKind) }
     private var messageCellContextMenu: (Message) -> AnyView = { _ in EmptyView().embedInAnyView() }
@@ -151,6 +152,7 @@ internal extension ChatView {
         ChatMessageCellContainer(
             message: message,
             size: size,
+            customCell: customCellView,
             onQuickReplyItemSelected: onQuickReplyItemSelected,
             contactFooterSection: contactCellFooterSection,
             onTextTappedCallback: onAttributedTextTappedCallback,
@@ -251,6 +253,11 @@ public extension ChatView {
 }
 
 public extension ChatView {
+    /// Registers a custom cell view
+    func registerCustomCell(customCell: @escaping (Any) -> AnyView) -> Self {
+        then({ $0.customCellView = customCell})
+    }
+    
     /// Triggered when a ChatMessage is tapped.
     func onMessageCellTapped(_ action: @escaping (Message) -> Void) -> Self {
         then({ $0.onMessageCellTapped = action })

--- a/Sources/SwiftyChat/Mock/MockMessages.swift
+++ b/Sources/SwiftyChat/Mock/MockMessages.swift
@@ -28,6 +28,7 @@ public struct MockMessages {
         case QuickReply
         case Carousel
         case Video
+        case Custom
         
         private var messageKind: ChatMessageKind {
             switch self {
@@ -38,6 +39,7 @@ public struct MockMessages {
             case .QuickReply: return .quickReply([])
             case .Carousel: return .carousel([CarouselRow(title: "", imageURL: nil, subtitle: "", buttons: [])])
             case .Video: return .video(VideoRow(url: URL(string: "")!, placeholderImage: .remote(URL(string: "")!), pictureInPicturePlayingMessage: ""))
+            case .Custom: return .custom("")
             }
         }
     }
@@ -236,6 +238,12 @@ public struct MockMessages {
                 messageKind: .video(videoItem),
                 isSender: randomUser == Self.sender
             )
+        case .Custom:
+            return ChatMessageItem(
+                user: randomUser,
+                messageKind: .custom(Lorem.sentence()),
+                isSender: randomUser == Self.sender
+            )
             
         }
     }
@@ -250,7 +258,8 @@ public struct MockMessages {
             .Location,
             .Text, .Text, .Text,
             .Video,
-            .QuickReply
+            .QuickReply,
+            .Custom
         ]
         return allCases.randomElement()!
     }

--- a/Sources/SwiftyChat/Model/ChatMessageKind.swift
+++ b/Sources/SwiftyChat/Model/ChatMessageKind.swift
@@ -43,6 +43,9 @@ public enum ChatMessageKind: CustomStringConvertible {
     /// Loading indicator contained in chat bubble
     case loading
     
+    /// A custom message cell
+    case custom(Any)
+    
     public var description: String {
         switch self {
         case .image(let imageLoadingType):
@@ -74,6 +77,8 @@ public enum ChatMessageKind: CustomStringConvertible {
             return "MessageKind.video(url: \(videoItem.url))"
         case .loading:
             return "MessageKind.loading"
+        case .custom:
+            return "MessageKind.custom"
         }
     }
     

--- a/SwiftyChatExample/SwiftyChatExample/AdvancedExampleView.swift
+++ b/SwiftyChatExample/SwiftyChatExample/AdvancedExampleView.swift
@@ -58,6 +58,8 @@ struct AdvancedExampleView: View {
             .embedInAnyView()
             
         }
+        // ▼ Optional, Implement to register a custom cell for Messagekind.custom
+        .registerCustomCell(customCell: { anyParam in AnyView(CustomExampleChatCell(anyParam: anyParam))})
         // ▼ Optional, Implement to be notified when related cell tapped
         .onMessageCellTapped({ (message) in
             print(message.messageKind.description)
@@ -139,7 +141,21 @@ struct AdvancedExampleView: View {
             
         }
     }
+}
+
+struct CustomExampleChatCell: View {
+    var anyParam: Any
     
+    var body: some View {
+        VStack{
+            Text((anyParam as? String) ?? "Not a String")
+                .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity)
+                .padding(5)
+                                
+        }
+        .background(Color.green)
+        .cornerRadius(25)
+    }
 }
 
 struct ContentView_Previews: PreviewProvider {


### PR DESCRIPTION
You can now register your own custom chat cells for the .custom MessageKind.

This feature was already requested in an [issue thread](https://github.com/EnesKaraosman/SwiftyChat/issues/26).